### PR TITLE
Consider the biggest side of the image as the width for the resize

### DIFF
--- a/rom/rom.go
+++ b/rom/rom.go
@@ -328,8 +328,16 @@ func getImage(url string, p string, w uint) error {
 	if err != nil {
 		return err
 	}
-	if w > 0 && uint(img.Bounds().Dx()) > w {
-		img = resize.Resize(w, 0, img, resize.Bilinear)
+	if w > 0 {
+		if uint(img.Bounds().Dx()) >= uint(img.Bounds().Dy()) {
+			if uint(img.Bounds().Dx()) > w {
+				img = resize.Resize(w, 0, img, resize.Bilinear)
+			}
+		} else {
+			if uint(img.Bounds().Dy()) > w {
+				img = resize.Resize(0, w, img, resize.Bilinear)
+			}
+		}
 	}
 	out, err := os.Create(p)
 	if err != nil {


### PR DESCRIPTION
I was thinking that since the image orientation (portrait vs landscape), especially for snes, we should consider a way to have images which have the same area, regardless of their orientation.

This is just a suggestion. Since, it is my first attempt to write Go code, so this is a quick hack.
So, there is room for improvement.
At least, you get the idea..
