### PR TITLE
hash: Add additional extension types for noop hash

### DIFF
--- a/rom/hash/hash.go
+++ b/rom/hash/hash.go
@@ -286,7 +286,11 @@ func getDecoder(ext string) (decoder, bool) {
 	switch strings.ToLower(ext) {
 	case ".bin", ".a26", ".a52", ".rom", ".cue", ".gdi", ".gb", ".gba", ".gbc", ".32x", ".gg",
 		".pce", ".sms", ".col", ".ngp", ".ngc", ".sg", ".int", ".vb", ".vec", ".gam", ".j64",
-		".jag", ".mgw", ".nds", ".fds":
+		".jag", ".mgw", ".nds", ".fds", ".a1", ".5e", ".610", ".6b",
+		".6d", ".u98", ".10b", ".109", ".e", ".6f", ".02", ".k17",
+		".16k", ".a11", ".ic41", ".ic55", ".35a", ".52", ".hj7",
+		".9m", ".snd", ".10a", ".10c", ".ic21", ".7f", ".105", ".6h",
+		".u19" :
 		return noop, true
 	case ".a78":
 		return decodeA78, true


### PR DESCRIPTION
This seems like kind of a hack, but it works reliably well for my full ROM suite and hasn't produced any false positives.  I considered adding a separate case condition that would do the same thing for this specific ROM set (mostly drawn from MAME 0.161) but it looks like there were already some MAME-specific ROM bits in the top conditional, so I went ahead and added them there.  I'm happy to re-work the commit if you prefer it to be broken out, though.

If you do merge this, then the corresponding updates I have to `hash.csv` can be found at http://pastebin.com/5FCFP73f