### PR TITLE
Reject Screensaver with empty overview

### DIFF
--- a/ds/ss.go
+++ b/ds/ss.go
@@ -288,7 +288,7 @@ func (s *SS) GetGame(id string) (*Game, error) {
 	if err == nil {
 		ret.Players = p
 	}
-	if ret.Overview == "" && ret.ReleaseDate == "" && ret.Developer == "" && ret.Publisher == "" && ret.Images[ImgBoxart] == "" && ret.Images[ImgScreen] == "" {
+	if ret.Overview == "" || ret.ReleaseDate == "" || ret.Developer == "" || ret.Publisher == "" || ret.Images[ImgBoxart] == "" || ret.Images[ImgScreen] == "" {
 		return nil, ErrNotFound
 	}
 	return ret, nil


### PR DESCRIPTION
I'm not sure whether this is a bug. But I would prefer to reject the found games with empty overview. 

For example, if I'm running:

`-lang=es -missing=missing.txt -refresh -use_ss -use_gdb=false -image_dir=downloaded_images -image_path=downloaded_images -workers=1`

I would expect it would only refresh the games with a description of the game. In any other case, leave it as it is.

What do you thing?