### PR TITLE
Add a transcode option.

### DIFF
--- a/rom/rom.go
+++ b/rom/rom.go
@@ -6,6 +6,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
+	"os/exec"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -78,6 +80,7 @@ type XMLOpts struct {
 	VidSuffix    string
 	VidDir       string
 	VidXMLDir    string
+	VidConvert   bool
 	DownloadMarq bool
 	MarqSuffix   string
 	MarqDir      string
@@ -382,6 +385,36 @@ func fileExists(p string, ext ...string) (string, bool) {
 	return p, false
 }
 
+// Not sure if this is the right place for this.
+func convertVideo(p string) error {
+	vidExt := path.Ext(p)
+	baseFile := p[:len(p)-len(vidExt)]
+	outputFile := baseFile + "-converting" + vidExt
+	// Hardcoded command for now, clean this up once we offer more
+	// conversion options.
+	cmd := exec.Command("HandBrakeCLI", "-i", p, "-o", outputFile,
+		"-e", "x264",
+		"-w", "320",
+		"-l", "240",
+		"-r", "30",
+		"--keep-display-aspect",
+		"--decomb",
+		"--audio", "1",
+		"-B", "80",
+		"-E", "av_aac")
+	err := cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(outputFile, p)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // XML creates the XML for the ROM after the Game has been populates.
 func (r *ROM) XML(ctx context.Context, opts *XMLOpts) (*GameXML, error) {
 	gxml := &GameXML{
@@ -444,7 +477,14 @@ func (r *ROM) XML(ctx context.Context, opts *XMLOpts) (*GameXML, error) {
 				}
 				return nil, err
 			}
+			if opts.VidConvert {
+				if err := convertVideo(newPath); err != nil {
+					return nil, err
+				}
+			}
+
 			gxml.Video = fixPath(opts.VidXMLDir + "/" + strings.TrimPrefix(newPath, opts.VidDir))
+
 		}
 	}
 	imgPath = getMarqPath(r, opts)

--- a/scraper.go
+++ b/scraper.go
@@ -61,6 +61,7 @@ var consoleSrcs = flag.String("console_src", "gdb", "Comma seperated order to pr
 var stripUnicode = flag.Bool("strip_unicode", false, "If true, remove all non-ascii characters.")
 var downloadImages = flag.Bool("download_images", true, "If false, don't download any images, instead see if the expected file is stored locally already.")
 var downloadVideos = flag.Bool("download_videos", false, "If true, download videos.")
+var convertVideos = flag.Bool("convert_videos", false, "If true, convert videos for the Raspberry Pi (e.g. 320x240@30fps) NOTE: This needs HandBrakeCLI installed")
 var downloadMarquees = flag.Bool("download_marquees", false, "If true, download marquees.")
 var scrapeAll = flag.Bool("scrape_all", false, "If true, scrape all systems listed in es_systems.cfg. All dir/path flags will be ignored.")
 var consoleImg = flag.String("console_img", "b", "Comma seperated order to prefer images, s=snapshot, b=boxart, f=fanart, a=banner, l=logo, 3b=3D boxart, mix3=Standard 3 mix, mix4=Standard 4 mix.")
@@ -516,6 +517,7 @@ func main() {
 		VidDir:       *videoDir,
 		VidXMLDir:    *videoPath,
 		VidSuffix:    *videoSuffix,
+		VidConvert:   *convertVideos,
 		MarqDir:      *marqueeDir,
 		MarqXMLDir:   *marqueePath,
 		MarqSuffix:   *marqueeSuffix,


### PR DESCRIPTION
Because all the videos from screenscraper.fr are too heavy for the poor
raspberry pi, I've added an option to the scraper to transcode them on
download. This will save me lots of time when scraping as I won't have
to manually transcode the videos. Note that this requires HandBrakeCLI
to be installed and it's probably not the best idea to do it on the Pi
itself as it's pretty CPU intensive.