### PR TITLE
reencode videos with ffmpeg instead of HandBrakeCli

### DIFF
--- a/rom/rom.go
+++ b/rom/rom.go
@@ -25,7 +25,7 @@ var vidExts = []string{".mp4", ".mkv", ".flv", ".ogv", ".avi", ".mov", ".mpg", "
 func init() {
 	SetMaxImg(runtime.NumCPU())
 	if runtime.GOOS == "windows" {
-		os.Setenv("PATH", fmt.Sprintf("C:\\Program Files\\Handbrake;%s", os.Getenv("PATH")))
+		os.Setenv("PATH", fmt.Sprintf("C:\\Program Files\\FFmpeg;%s", os.Getenv("PATH")))
 	}
 }
 
@@ -389,24 +389,23 @@ func fileExists(p string, ext ...string) (string, bool) {
 	return p, false
 }
 
-// convertVideo transcodes a video using HandBrakeCLI.
+// convertVideo transcodes a video using ffmpeg.
 func convertVideo(p string) error {
 	vidExt := filepath.Ext(p)
 	baseFile := p[:len(p)-len(vidExt)]
 	outputFile := baseFile + "-converting" + vidExt
 	// Hardcoded command for now, clean this up once we offer more
 	// conversion options.
-	cmd := exec.Command("HandBrakeCLI", "-i", p, "-o", outputFile,
-		"-e", "x264",
-		"-w", "320",
-		"-l", "240",
-		"-r", "30",
-		"--keep-display-aspect",
-		"--decomb",
-		"--audio", "1",
-		"-B", "80",
-		"-E", "av_aac")
+	cmd := exec.Command("ffmpeg", "-i", p,
+		"-c:v", "libx264",
+        "-preset", "fast",
+        "-crf", "23",
+        "-vf", "scale=w=320:h=240:force_original_aspect_ratio=decrease",
+        "-c:a", "aac",
+        "-b:a", "80k",
+        outputFile)
 	if err := cmd.Run(); err != nil {
+        fmt.Println("hello world") 
 		return err
 	}
 	return os.Rename(outputFile, p)

--- a/rom/rom.go
+++ b/rom/rom.go
@@ -405,7 +405,6 @@ func convertVideo(p string) error {
         "-b:a", "80k",
         outputFile)
 	if err := cmd.Run(); err != nil {
-        fmt.Println("hello world") 
 		return err
 	}
 	return os.Rename(outputFile, p)

--- a/scraper.go
+++ b/scraper.go
@@ -61,7 +61,7 @@ var consoleSrcs = flag.String("console_src", "gdb", "Comma seperated order to pr
 var stripUnicode = flag.Bool("strip_unicode", false, "If true, remove all non-ascii characters.")
 var downloadImages = flag.Bool("download_images", true, "If false, don't download any images, instead see if the expected file is stored locally already.")
 var downloadVideos = flag.Bool("download_videos", false, "If true, download videos.")
-var convertVideos = flag.Bool("convert_videos", false, "If true, convert videos for the Raspberry Pi (e.g. 320x240@30fps) NOTE: This needs HandBrakeCLI installed")
+var convertVideos = flag.Bool("convert_videos", false, "If true, convert videos for the Raspberry Pi (e.g. 320x240@30fps) NOTE: This needs ffmpeg installed")
 var downloadMarquees = flag.Bool("download_marquees", false, "If true, download marquees.")
 var scrapeAll = flag.Bool("scrape_all", false, "If true, scrape all systems listed in es_systems.cfg. All dir/path flags will be ignored.")
 var consoleImg = flag.String("console_img", "b", "Comma seperated order to prefer images, s=snapshot, b=boxart, f=fanart, a=banner, l=logo, 3b=3D boxart, cart=cartridge, clabel=cartridge label, mix3=Standard 3 mix, mix4=Standard 4 mix.")


### PR DESCRIPTION
HandBrake uses FFmpeg behind the curtains anyway and does not really add any command line options which can not be achieved directly with ffmpeg.

compiling ffmpeg on a raspberry pi for example is also easier than HandBrake.
FFmpeg also provides Linux, Windows and MacOS binaries