### PR TITLE
hash: add support for WonderSwan and WonderSwan Color.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ scraper
 [![Build Status](https://travis-ci.org/sselph/scraper.svg?branch=master)](https://travis-ci.org/sselph/scraper) [![GoDoc](https://godoc.org/github.com/sselph/scraper?status.svg)](https://godoc.org/github.com/sselph/scraper)
 
 An auto-scraper for EmulationStation written in Go using hashes.
-This currently works with NES, SNES, N64, GB, GBC, GBA, MD, SMS, 32X, GG, PCE, A2600, LNX, MAME/FBA(see below), Dreamcast(bin/gdi), PSX(bin/cue), ScummVM, SegaCD ROMs.
+This currently works with NES, SNES, N64, GB, GBC, GBA, MD, SMS, 32X, GG, PCE, A2600, LNX, MAME/FBA(see below), Dreamcast(bin/gdi), PSX(bin/cue), ScummVM, SegaCD, WonderSwan, WonderSwan Color ROMs.
 
 How it Works
 ------------

--- a/rom/hash/hash.go
+++ b/rom/hash/hash.go
@@ -322,7 +322,7 @@ func getDecoder(ext string) (decoder, bool) {
 	switch ext {
 	case ".bin", ".a26", ".a52", ".rom", ".cue", ".gdi", ".gb", ".gba", ".gbc", ".32x", ".gg",
 		".pce", ".sms", ".col", ".ngp", ".ngc", ".sg", ".int", ".vb", ".vec", ".gam", ".j64",
-		".jag", ".mgw", ".nds", ".fds", ".ctg", ".sgx", ".tgx":
+		".jag", ".mgw", ".nds", ".fds", ".ctg", ".sgx", ".tgx", ".ws", ".wsc":
 		return noop, true
 	case ".a78":
 		return decodeA78, true


### PR DESCRIPTION
Add  `.ws` and `.wsc` to known extensions. Brag about it in README.