### PR TITLE
Added iso support as it’s standard for some DVD images

### DIFF
--- a/rom/hash/hash.go
+++ b/rom/hash/hash.go
@@ -322,7 +322,7 @@ func getDecoder(ext string) (decoder, bool) {
 	switch ext {
 	case ".bin", ".a26", ".a52", ".rom", ".cue", ".gdi", ".gb", ".gba", ".gbc", ".32x", ".gg",
 		".pce", ".sms", ".col", ".ngp", ".ngc", ".sg", ".int", ".vb", ".vec", ".gam", ".j64",
-		".jag", ".mgw", ".nds", ".fds", ".ctg", ".sgx", ".tgx", ".ws", ".wsc":
+		".jag", ".mgw", ".nds", ".fds", ".ctg", ".sgx", ".tgx", ".ws", ".wsc", ".iso":
 		return noop, true
 	case ".a78":
 		return decodeA78, true


### PR DESCRIPTION
Currently scraper will ignore any iso images, and the only way to get it to scan them is to know to add `-extra_ext=".iso"` as you mentioned here: https://github.com/sselph/scraper/issues/71

You also mentioned that _"iso isn't a supported format on any system so it ignores it"_, however in the time since then that is no longer the case. REDUMP uses bin/cue for CD images and iso for DVD images for many systems. They specify them here: http://wiki.redump.org/index.php?title=Dumping-Guides

The most common system being PS2. So in the REDUMP PS2 set, all DVD images are in iso format while only the CD images are in bin/cue format. As most PS2 games are on DVD, this means that scraper, by default, doesn't handle this set very well. 

When I scanned my files, scraper worked fine with the CD games, but skipped all of the DVD games telling me there were no rom files in the 7z archives. Once I made this code change, scraper happily hashed and found every one of my games, so clearly the games are in your hash database and I think will be quite common with users as REDUMP is basically No-Intro for disc based systems.

I think it's worth having implicit support for iso files rather than requiring the user to know to add the `-extra_ext=".iso"` option. I initially thought it was a bug, and I assume many others have as well.