### PR TITLE
Update to support TheGamesDB v2 api

### DIFF
--- a/ds/daphne.go
+++ b/ds/daphne.go
@@ -52,8 +52,7 @@ func (d *Daphne) GetGame(ctx context.Context, p string) (*Game, error) {
 	if err != nil {
 		return nil, err
 	}
-	req := gdb.GGReq{ID: id}
-	resp, err := gdb.GetGame(ctx, d.APIKey, req)
+	resp, err := gdb.GetGame(ctx, d.APIKey, id)
 	if err != nil {
 		return nil, err
 	}

--- a/ds/daphne.go
+++ b/ds/daphne.go
@@ -1,12 +1,8 @@
 package ds
 
 import (
-	"context"
-	"fmt"
 	"path/filepath"
 	"strings"
-
-	"github.com/sselph/scraper/gdb"
 )
 
 // Daphne is a data source using GDB for Daphne games.
@@ -46,21 +42,21 @@ func (d *Daphne) GetName(p string) string {
 }
 
 // GetGame implements DS.
-func (d *Daphne) GetGame(ctx context.Context, p string) (*Game, error) {
-	id, err := d.getID(p)
-	if err != nil {
-		return nil, err
-	}
-	req := gdb.GGReq{ID: id}
-	resp, err := gdb.GetGame(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if len(resp.Game) == 0 {
-		return nil, fmt.Errorf("game with id (%s) not found", id)
-	}
-	game := resp.Game[0]
-	ret := ParseGDBGame(game, resp.ImageURL)
-	ret.ID = id
-	return ret, nil
-}
+//func (d *Daphne) GetGame(ctx context.Context, p string) (*Game, error) {
+//	id, err := d.getID(p)
+//	if err != nil {
+//		return nil, err
+//	}
+//	req := gdb.GGReq{ID: id}
+//	resp, err := gdb.GetGame(ctx, req)
+//	if err != nil {
+//		return nil, err
+//	}
+//	if len(resp.Game) == 0 {
+//		return nil, fmt.Errorf("game with id (%s) not found", id)
+//	}
+//	game := resp.Game[0]
+//	ret := ParseGDBGame(game, resp.ImageURL)
+//	ret.ID = id
+//	return ret, nil
+//}

--- a/ds/daphne.go
+++ b/ds/daphne.go
@@ -1,13 +1,18 @@
 package ds
 
 import (
+	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/sselph/scraper/gdb"
 )
 
 // Daphne is a data source using GDB for Daphne games.
 type Daphne struct {
-	HM *HashMap
+	HM     *HashMap
+	APIKey string
 }
 
 // GetID implements DS.
@@ -42,21 +47,20 @@ func (d *Daphne) GetName(p string) string {
 }
 
 // GetGame implements DS.
-//func (d *Daphne) GetGame(ctx context.Context, p string) (*Game, error) {
-//	id, err := d.getID(p)
-//	if err != nil {
-//		return nil, err
-//	}
-//	req := gdb.GGReq{ID: id}
-//	resp, err := gdb.GetGame(ctx, req)
-//	if err != nil {
-//		return nil, err
-//	}
-//	if len(resp.Game) == 0 {
-//		return nil, fmt.Errorf("game with id (%s) not found", id)
-//	}
-//	game := resp.Game[0]
-//	ret := ParseGDBGame(game, resp.ImageURL)
-//	ret.ID = id
-//	return ret, nil
-//}
+func (d *Daphne) GetGame(ctx context.Context, p string) (*Game, error) {
+	id, err := d.getID(p)
+	if err != nil {
+		return nil, err
+	}
+	req := gdb.GGReq{ID: id}
+	resp, err := gdb.GetGame(ctx, d.APIKey, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("game with id (%s) not found", id)
+	}
+
+	result := ParseGDBGame(*resp)
+	return result, nil
+}

--- a/ds/ds.go
+++ b/ds/ds.go
@@ -57,7 +57,7 @@ const (
 	ImgMix4      ImgType = "mix4"
 )
 
-// VidTtpe represents the different video types that sources may provide.
+// VidType represents the different video types that sources may provide.
 type VidType string
 
 // Video types for Datasource options. Not all types are valid for all sources.

--- a/ds/gdb.go
+++ b/ds/gdb.go
@@ -166,8 +166,7 @@ func (g *GDB) GetGame(ctx context.Context, p string) (*Game, error) {
 	if err != nil {
 		return nil, err
 	}
-	req := gdb.GGReq{ID: id}
-	resp, err := gdb.GetGame(ctx, g.APIKey, req)
+	resp, err := gdb.GetGame(ctx, g.APIKey, id)
 	if err != nil {
 		return nil, err
 	}

--- a/ds/gdb.go
+++ b/ds/gdb.go
@@ -154,7 +154,7 @@ func parseImages(game gdb.ParsedGame) (map[ImgType]Image, map[ImgType]Image) {
 func ParseGDBGame(game gdb.ParsedGame) *Game {
 	ret := NewGame()
 
-	ret.ID = string(game.ID)
+	ret.ID = strconv.Itoa(game.ID)
 	ret.GameTitle = game.Name
 	ret.Overview = game.Overview
 	ret.ReleaseDate = toXMLDate(game.ReleaseDate)

--- a/ds/gdb.go
+++ b/ds/gdb.go
@@ -56,37 +56,6 @@ func (g *GDB) getID(p string) (string, error) {
 	return id, nil
 }
 
-// GetName implements DS
-func (g *GDB) GetName(p string) string {
-	h, err := g.Hasher.Hash(p)
-	if err != nil {
-		return ""
-	}
-	name, ok := g.HM.Name(h)
-	if !ok {
-		return ""
-	}
-	return name
-}
-
-// GetGame implements DS
-func (g *GDB) GetGame(ctx context.Context, p string) (*Game, error) {
-	id, err := g.getID(p)
-	if err != nil {
-		return nil, err
-	}
-	req := gdb.GGReq{ID: id}
-	resp, err := gdb.GetGame(ctx, g.APIKey, req)
-	if err != nil {
-		return nil, err
-	}
-	if resp == nil {
-		return nil, fmt.Errorf("game with id (%s) not found", id)
-	}
-
-	return ParseGDBGame(*resp), nil
-}
-
 type ImageTypeName string
 
 func bucketImagesByType(images []gdb.ParsedGameImage) map[ImageTypeName][]gdb.ParsedGameImage {
@@ -176,4 +145,36 @@ func ParseGDBGame(game gdb.ParsedGame) *Game {
 
 	ret.Source = "theGamesDB.net"
 	return ret
+}
+
+// GetName implements DS
+func (g *GDB) GetName(p string) string {
+	h, err := g.Hasher.Hash(p)
+	if err != nil {
+		return ""
+	}
+	name, ok := g.HM.Name(h)
+	if !ok {
+		return ""
+	}
+	return name
+}
+
+// GetGame implements DS
+func (g *GDB) GetGame(ctx context.Context, p string) (*Game, error) {
+	id, err := g.getID(p)
+	if err != nil {
+		return nil, err
+	}
+	req := gdb.GGReq{ID: id}
+	resp, err := gdb.GetGame(ctx, g.APIKey, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("game with id (%s) not found", id)
+	}
+
+	result := ParseGDBGame(*resp)
+	return result, nil
 }

--- a/ds/gdb.go
+++ b/ds/gdb.go
@@ -63,10 +63,7 @@ func bucketImagesByType(images []gdb.ParsedGameImage) map[ImageTypeName][]gdb.Pa
 
 	for _, image := range images {
 		imageType := ImageTypeName(image.Type)
-		existing := res[imageType]
-
-		existing = append(existing, image)
-		res[imageType] = existing
+		res[imageType] = append(res[imageType], image)
 	}
 
 	return res

--- a/ds/gdb.go
+++ b/ds/gdb.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
+	gamesdb "github.com/J-Swift/thegamesdb-swagger-client-go"
 	"github.com/sselph/scraper/gdb"
 )
 
@@ -14,13 +14,14 @@ import (
 type GDB struct {
 	HM     *HashMap
 	Hasher *Hasher
+	APIKey string
 }
 
 // getFront gets the front boxart for a Game if it exists.
-func getFront(g gdb.Game) *gdb.Image {
-	for _, v := range g.BoxArt {
-		if v.Side == "front" {
-			return &v
+func getFront(images []gamesdb.GameImage) *gamesdb.GameImage {
+	for _, image := range images {
+		if image.Side == "front" {
+			return &image
 		}
 	}
 	return nil
@@ -30,7 +31,7 @@ func getFront(g gdb.Game) *gdb.Image {
 func toXMLDate(d string) string {
 	switch len(d) {
 	case 10:
-		t, _ := time.Parse("01/02/2006", d)
+		t, _ := time.Parse("2006-01-02", d)
 		return t.Format("20060102T000000")
 	case 4:
 		return fmt.Sprintf("%s0101T000000", d)
@@ -76,59 +77,102 @@ func (g *GDB) GetGame(ctx context.Context, p string) (*Game, error) {
 		return nil, err
 	}
 	req := gdb.GGReq{ID: id}
-	resp, err := gdb.GetGame(ctx, req)
+	resp, err := gdb.GetGame(ctx, g.APIKey, req)
 	if err != nil {
 		return nil, err
 	}
-	if len(resp.Game) == 0 {
+	if len(resp.Games) == 0 {
 		return nil, fmt.Errorf("game with id (%s) not found", id)
 	}
-	game := resp.Game[0]
-	ret := ParseGDBGame(game, resp.ImageURL)
+	game := resp.Games[0]
+	ret := ParseGDBGame(game, resp.Boxart, resp.ImageBaseURL)
 	ret.ID = id
 	return ret, nil
 }
 
-// ParseGDBGame parses a gdb.Game and returns a Game.
-func ParseGDBGame(game gdb.Game, imgURL string) *Game {
-	ret := NewGame()
-	if len(game.Screenshot) != 0 {
-		ret.Images[ImgScreen] = HTTPImage{URL: imgURL + game.Screenshot[0].Original.URL}
-		ret.Thumbs[ImgScreen] = HTTPImage{URL: imgURL + game.Screenshot[0].Thumb}
-	}
-	front := getFront(game)
-	if front != nil {
-		ret.Images[ImgBoxart] = HTTPImage{URL: imgURL + front.URL}
-		ret.Thumbs[ImgBoxart] = HTTPImage{URL: imgURL + front.Thumb}
-	}
-	if len(game.FanArt) != 0 {
-		ret.Images[ImgFanart] = HTTPImage{URL: imgURL + game.FanArt[0].Original.URL}
-		ret.Thumbs[ImgFanart] = HTTPImage{URL: imgURL + game.FanArt[0].Thumb}
-	}
-	if len(game.Banner) != 0 {
-		ret.Images[ImgBanner] = HTTPImage{URL: imgURL + game.Banner[0].URL}
-		ret.Thumbs[ImgBanner] = HTTPImage{URL: imgURL + game.Banner[0].URL}
-	}
-	if len(game.ClearLogo) != 0 {
-		ret.Images[ImgLogo] = HTTPImage{URL: imgURL + game.ClearLogo[0].URL}
-		ret.Thumbs[ImgLogo] = HTTPImage{URL: imgURL + game.ClearLogo[0].URL}
+type ImageTypeName string
+
+func bucketImagesByType(images []gamesdb.GameImage) map[ImageTypeName][]gamesdb.GameImage {
+	res := make(map[ImageTypeName][]gamesdb.GameImage)
+
+	for _, image := range images {
+		imageType := ImageTypeName(image.Type)
+		existing := res[imageType]
+
+		existing = append(existing, image)
+		res[imageType] = existing
 	}
 
-	var genre string
-	if len(game.Genres) >= 1 {
-		genre = game.Genres[0]
+	return res
+}
+
+func parseImages(game gamesdb.Game, images map[string][]gamesdb.GameImage, baseUrls gamesdb.ImageBaseUrlMeta) (map[ImgType]Image, map[ImgType]Image) {
+	originals := make(map[ImgType]Image)
+	thumbs := make(map[ImgType]Image)
+
+	baseURLOriginal := baseUrls.Original
+	baseURLThumb := baseUrls.Thumb
+
+	gameImages := images[strconv.Itoa(int(game.Id))]
+
+	if len(gameImages) != 0 {
+		bucketedImages := bucketImagesByType(gameImages)
+
+		if imgs, ok := bucketedImages["screenshot"]; ok && len(imgs) > 0 {
+			img := imgs[0]
+			originals[ImgScreen] = HTTPImage{URL: baseURLOriginal + img.Filename}
+			thumbs[ImgScreen] = HTTPImage{URL: baseURLThumb + img.Filename}
+		}
+
+		if imgs, ok := bucketedImages["boxart"]; ok && len(imgs) > 0 {
+			if front := getFront(imgs); front != nil {
+				originals[ImgBoxart] = HTTPImage{URL: baseURLOriginal + front.Filename}
+				thumbs[ImgBoxart] = HTTPImage{URL: baseURLThumb + front.Filename}
+			}
+		}
+
+		if imgs, ok := bucketedImages["fanart"]; ok && len(imgs) > 0 {
+			img := imgs[0]
+			originals[ImgFanart] = HTTPImage{URL: baseURLOriginal + img.Filename}
+			thumbs[ImgFanart] = HTTPImage{URL: baseURLThumb + img.Filename}
+		}
+
+		if imgs, ok := bucketedImages["banner"]; ok && len(imgs) > 0 {
+			img := imgs[0]
+			originals[ImgBanner] = HTTPImage{URL: baseURLOriginal + img.Filename}
+			thumbs[ImgBanner] = HTTPImage{URL: baseURLThumb + img.Filename}
+		}
+
+		if imgs, ok := bucketedImages["clearlogo"]; ok && len(imgs) > 0 {
+			img := imgs[0]
+			originals[ImgLogo] = HTTPImage{URL: baseURLOriginal + img.Filename}
+			thumbs[ImgLogo] = HTTPImage{URL: baseURLThumb + img.Filename}
+		}
 	}
+
+	return originals, thumbs
+}
+
+// ParseGDBGame parses a gdb.Game and returns a Game.
+func ParseGDBGame(game gamesdb.Game, images map[string][]gamesdb.GameImage, baseUrls gamesdb.ImageBaseUrlMeta) *Game {
+	ret := NewGame()
+
+	parsedImages, parsedThumbs := parseImages(game, images, baseUrls)
+	ret.Images = parsedImages
+	ret.Thumbs = parsedThumbs
+
+	//var genre string
+	//if len(game.Genres) >= 1 {
+	//genre = game.Genres[0]
+	//}
 	ret.GameTitle = game.GameTitle
 	ret.Overview = game.Overview
-	ret.Rating = game.Rating / 10.0
+	// ret.Rating = game.Rating / 10.0
 	ret.ReleaseDate = toXMLDate(game.ReleaseDate)
-	ret.Developer = game.Developer
-	ret.Publisher = game.Publisher
-	ret.Genre = genre
+	//ret.Developer = game.Developer
+	//ret.Publisher = game.Publisher
+	//ret.Genre = genre
 	ret.Source = "theGamesDB.net"
-	p, err := strconv.ParseInt(strings.TrimRight(game.Players, "+"), 10, 32)
-	if err == nil {
-		ret.Players = p
-	}
+	ret.Players = int64(game.Players)
 	return ret
 }

--- a/ds/neogeo.go
+++ b/ds/neogeo.go
@@ -46,8 +46,7 @@ func (n *NeoGeo) GetGame(ctx context.Context, p string) (*Game, error) {
 	if err != nil {
 		return nil, err
 	}
-	req := gdb.GGReq{ID: id}
-	resp, err := gdb.GetGame(ctx, n.APIKey, req)
+	resp, err := gdb.GetGame(ctx, n.APIKey, id)
 	if err != nil {
 		return nil, err
 	}

--- a/ds/neogeo.go
+++ b/ds/neogeo.go
@@ -1,11 +1,7 @@
 package ds
 
 import (
-	"context"
-	"fmt"
 	"path/filepath"
-
-	"github.com/sselph/scraper/gdb"
 )
 
 // NeoGeo is a data source using GDB for Daphne games.
@@ -40,25 +36,25 @@ func (n *NeoGeo) GetName(p string) string {
 }
 
 // GetGame implements DS.
-func (n *NeoGeo) GetGame(ctx context.Context, p string) (*Game, error) {
-	id, err := n.getID(p)
-	if err != nil {
-		return nil, err
-	}
-	req := gdb.GGReq{ID: id}
-	resp, err := gdb.GetGame(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if len(resp.Game) == 0 {
-		return nil, fmt.Errorf("game with id (%s) not found", id)
-	}
-	game := resp.Game[0]
-	ret := ParseGDBGame(game, resp.ImageURL)
-	ret.ID = id
-	ret.Images[ImgTitle] = ret.Images[ImgBoxart]
-	ret.Thumbs[ImgTitle] = ret.Thumbs[ImgBoxart]
-	ret.Images[ImgMarquee] = ret.Images[ImgLogo]
-	ret.Thumbs[ImgMarquee] = ret.Thumbs[ImgLogo]
-	return ret, nil
-}
+//func (n *NeoGeo) GetGame(ctx context.Context, p string) (*Game, error) {
+//	id, err := n.getID(p)
+//	if err != nil {
+//		return nil, err
+//	}
+//	req := gdb.GGReq{ID: id}
+//	resp, err := gdb.GetGame(ctx, req)
+//	if err != nil {
+//		return nil, err
+//	}
+//	if len(resp.Game) == 0 {
+//		return nil, fmt.Errorf("game with id (%s) not found", id)
+//	}
+//	game := resp.Game[0]
+//	ret := ParseGDBGame(game, resp.ImageURL)
+//	ret.ID = id
+//	ret.Images[ImgTitle] = ret.Images[ImgBoxart]
+//	ret.Thumbs[ImgTitle] = ret.Thumbs[ImgBoxart]
+//	ret.Images[ImgMarquee] = ret.Images[ImgLogo]
+//	ret.Thumbs[ImgMarquee] = ret.Thumbs[ImgLogo]
+//	return ret, nil
+//}

--- a/ds/neogeo.go
+++ b/ds/neogeo.go
@@ -1,12 +1,17 @@
 package ds
 
 import (
+	"context"
+	"fmt"
 	"path/filepath"
+
+	"github.com/sselph/scraper/gdb"
 )
 
 // NeoGeo is a data source using GDB for Daphne games.
 type NeoGeo struct {
-	HM *HashMap
+	HM     *HashMap
+	APIKey string
 }
 
 // getID gets the ID from the path.
@@ -36,25 +41,24 @@ func (n *NeoGeo) GetName(p string) string {
 }
 
 // GetGame implements DS.
-//func (n *NeoGeo) GetGame(ctx context.Context, p string) (*Game, error) {
-//	id, err := n.getID(p)
-//	if err != nil {
-//		return nil, err
-//	}
-//	req := gdb.GGReq{ID: id}
-//	resp, err := gdb.GetGame(ctx, req)
-//	if err != nil {
-//		return nil, err
-//	}
-//	if len(resp.Game) == 0 {
-//		return nil, fmt.Errorf("game with id (%s) not found", id)
-//	}
-//	game := resp.Game[0]
-//	ret := ParseGDBGame(game, resp.ImageURL)
-//	ret.ID = id
-//	ret.Images[ImgTitle] = ret.Images[ImgBoxart]
-//	ret.Thumbs[ImgTitle] = ret.Thumbs[ImgBoxart]
-//	ret.Images[ImgMarquee] = ret.Images[ImgLogo]
-//	ret.Thumbs[ImgMarquee] = ret.Thumbs[ImgLogo]
-//	return ret, nil
-//}
+func (n *NeoGeo) GetGame(ctx context.Context, p string) (*Game, error) {
+	id, err := n.getID(p)
+	if err != nil {
+		return nil, err
+	}
+	req := gdb.GGReq{ID: id}
+	resp, err := gdb.GetGame(ctx, n.APIKey, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("game with id (%s) not found", id)
+	}
+
+	result := ParseGDBGame(*resp)
+	result.Images[ImgTitle] = result.Images[ImgBoxart]
+	result.Thumbs[ImgTitle] = result.Thumbs[ImgBoxart]
+	result.Images[ImgMarquee] = result.Images[ImgLogo]
+	result.Thumbs[ImgMarquee] = result.Thumbs[ImgLogo]
+	return result, nil
+}

--- a/ds/scumm.go
+++ b/ds/scumm.go
@@ -48,8 +48,7 @@ func (s *ScummVM) GetGame(ctx context.Context, p string) (*Game, error) {
 	if err != nil {
 		return nil, err
 	}
-	req := gdb.GGReq{ID: id}
-	resp, err := gdb.GetGame(ctx, s.APIKey, req)
+	resp, err := gdb.GetGame(ctx, s.APIKey, id)
 	if err != nil {
 		return nil, err
 	}

--- a/ds/scumm.go
+++ b/ds/scumm.go
@@ -1,13 +1,18 @@
 package ds
 
 import (
+	"context"
+	"fmt"
 	"path/filepath"
 	"strings"
+
+	"github.com/sselph/scraper/gdb"
 )
 
 // ScummVM is a data source using GDB for ScummVM games.
 type ScummVM struct {
-	HM *HashMap
+	HM     *HashMap
+	APIKey string
 }
 
 // getID gets the ID from the path..
@@ -38,21 +43,20 @@ func (s *ScummVM) GetName(p string) string {
 }
 
 // GetGame implements DS.
-// func (s *ScummVM) GetGame(ctx context.Context, p string) (*Game, error) {
-// 	id, err := s.getID(p)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	req := gdb.GGReq{ID: id}
-// 	resp, err := gdb.GetGame(ctx, req)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	if len(resp.Game) == 0 {
-// 		return nil, fmt.Errorf("game with id (%s) not found", id)
-// 	}
-// 	game := resp.Game[0]
-// 	ret := ParseGDBGame(game, resp.ImageURL)
-// 	ret.ID = id
-// 	return ret, nil
-// }
+func (s *ScummVM) GetGame(ctx context.Context, p string) (*Game, error) {
+	id, err := s.getID(p)
+	if err != nil {
+		return nil, err
+	}
+	req := gdb.GGReq{ID: id}
+	resp, err := gdb.GetGame(ctx, s.APIKey, req)
+	if err != nil {
+		return nil, err
+	}
+	if resp == nil {
+		return nil, fmt.Errorf("game with id (%s) not found", id)
+	}
+
+	result := ParseGDBGame(*resp)
+	return result, nil
+}

--- a/ds/scumm.go
+++ b/ds/scumm.go
@@ -1,12 +1,8 @@
 package ds
 
 import (
-	"context"
-	"fmt"
 	"path/filepath"
 	"strings"
-
-	"github.com/sselph/scraper/gdb"
 )
 
 // ScummVM is a data source using GDB for ScummVM games.
@@ -42,21 +38,21 @@ func (s *ScummVM) GetName(p string) string {
 }
 
 // GetGame implements DS.
-func (s *ScummVM) GetGame(ctx context.Context, p string) (*Game, error) {
-	id, err := s.getID(p)
-	if err != nil {
-		return nil, err
-	}
-	req := gdb.GGReq{ID: id}
-	resp, err := gdb.GetGame(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if len(resp.Game) == 0 {
-		return nil, fmt.Errorf("game with id (%s) not found", id)
-	}
-	game := resp.Game[0]
-	ret := ParseGDBGame(game, resp.ImageURL)
-	ret.ID = id
-	return ret, nil
-}
+// func (s *ScummVM) GetGame(ctx context.Context, p string) (*Game, error) {
+// 	id, err := s.getID(p)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	req := gdb.GGReq{ID: id}
+// 	resp, err := gdb.GetGame(ctx, req)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	if len(resp.Game) == 0 {
+// 		return nil, fmt.Errorf("game with id (%s) not found", id)
+// 	}
+// 	game := resp.Game[0]
+// 	ret := ParseGDBGame(game, resp.ImageURL)
+// 	ret.ID = id
+// 	return ret, nil
+// }

--- a/gdb/gdb.go
+++ b/gdb/gdb.go
@@ -1,7 +1,4 @@
 // Package gdb interacts with thegamedb.net's API.
-//
-// Example:
-//  resp, err := gdb.GetGame(GGReq{ID: "5"})
 package gdb
 
 import (
@@ -132,13 +129,6 @@ func getCachedGenres(ctx context.Context, apikey string) map[string]gamesdb.Genr
 	return *genres
 }
 
-//GGReq is the request to GetGame.
-type GGReq struct {
-	ID       string
-	Name     string
-	Platform string
-}
-
 // ParsedDeveloper is a normalized GamesDB Developer
 type ParsedDeveloper struct {
 	ID   int
@@ -188,7 +178,7 @@ type ParsedGame struct {
 }
 
 // GetGame gets the game information from the DB.
-func GetGame(ctx context.Context, apikey string, req GGReq) (*ParsedGame, error) {
+func GetGame(ctx context.Context, apikey string, gameID string) (*ParsedGame, error) {
 	var games gamesdb.GamesByGameId
 	var resp *http.Response
 	var err error
@@ -197,12 +187,8 @@ func GetGame(ctx context.Context, apikey string, req GGReq) (*ParsedGame, error)
 	//fields := "players,publishers,genres,overview,last_updated,rating,platform,coop,youtube,os,processor,ram,hdd,video,sound,alternates"
 	fields := "players,publishers,genres,overview,platform"
 
-	if req.ID != "" {
-		games, resp, err = apiClient.GamesApi.GamesByGameID(ctx, apikey, req.ID, &gamesdb.GamesByGameIDOpts{Fields: optional.NewString(fields)})
-	} else if req.Name != "" {
-		games, resp, err = apiClient.GamesApi.GamesByGameName(ctx, apikey, req.ID, &gamesdb.GamesByGameNameOpts{Fields: optional.NewString(fields)})
-		// TODO(jpr): handle platform
-		// apiClient.GamesApi.GamesByGameName(ctx, apikey, req.Name, gamesdb.GamesByGameNameOpts{FilterPlatform:}
+	if gameID != "" {
+		games, resp, err = apiClient.GamesApi.GamesByGameID(ctx, apikey, gameID, &gamesdb.GamesByGameIDOpts{Fields: optional.NewString(fields)})
 	} else {
 		return nil, fmt.Errorf("must provide an ID or Name")
 	}

--- a/gdb/gdb.go
+++ b/gdb/gdb.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
+	"sync"
 
 	"github.com/antihax/optional"
 
@@ -16,19 +18,119 @@ import (
 
 var apiClient = gamesdb.NewAPIClient(gamesdb.NewConfiguration())
 
-// GGLReq represents a request for a GetGameList command.
-// type GGLReq struct {
-// 	Name     string
-// 	Platform string
-// 	Genre    string
-// }
+// Publishers
 
-// GGLResp represents the response of a GetGameList command.
-//type GGLResp struct {
-//	XMLName xml.Name
-//	Game    []GameTrunc
-//	Err     string `xml:",chardata"`
-//}
+type publishers struct {
+	mux        sync.Mutex
+	publishers *map[string]gamesdb.Publisher
+}
+
+var publishersCache = publishers{}
+
+func getPublishers(ctx context.Context, apikey string) map[string]gamesdb.Publisher {
+	pubs, resp, err := apiClient.PublishersApi.Publishers(ctx, apikey)
+
+	if err != nil || resp.StatusCode != 200 {
+		return make(map[string]gamesdb.Publisher)
+	}
+
+	return pubs.Data.Publishers
+}
+
+func getCachedPublishers(ctx context.Context, apikey string) map[string]gamesdb.Publisher {
+	publishers := publishersCache.publishers
+	if publishers != nil {
+		return *publishers
+	}
+
+	publishersCache.mux.Lock()
+	defer publishersCache.mux.Unlock()
+
+	publishers = publishersCache.publishers
+	if publishers == nil {
+		apiPublishers := getPublishers(ctx, apikey)
+		publishers = &apiPublishers
+		publishersCache.publishers = publishers
+	}
+
+	return *publishers
+}
+
+// Developers
+
+type developers struct {
+	mux        sync.Mutex
+	developers *map[string]gamesdb.Developer
+}
+
+var developersCache = developers{}
+
+func getDevelopers(ctx context.Context, apikey string) map[string]gamesdb.Developer {
+	pubs, resp, err := apiClient.DevelopersApi.Developers(ctx, apikey)
+
+	if err != nil || resp.StatusCode != 200 {
+		return make(map[string]gamesdb.Developer)
+	}
+
+	return pubs.Data.Developers
+}
+
+func getCachedDevelopers(ctx context.Context, apikey string) map[string]gamesdb.Developer {
+	developers := developersCache.developers
+	if developers != nil {
+		return *developers
+	}
+
+	developersCache.mux.Lock()
+	defer developersCache.mux.Unlock()
+
+	developers = developersCache.developers
+	if developers == nil {
+		apiDevelopers := getDevelopers(ctx, apikey)
+		developers = &apiDevelopers
+		developersCache.developers = developers
+	}
+
+	return *developers
+}
+
+// Genres
+
+type genres struct {
+	mux    sync.Mutex
+	genres *map[string]gamesdb.Genre
+}
+
+var genresCache = genres{}
+
+func getGenres(ctx context.Context, apikey string) map[string]gamesdb.Genre {
+	pubs, resp, err := apiClient.GenresApi.Genres(ctx, apikey)
+
+	if err != nil || resp.StatusCode != 200 {
+		return make(map[string]gamesdb.Genre)
+	}
+
+	return pubs.Data.Genres
+}
+
+func getCachedGenres(ctx context.Context, apikey string) map[string]gamesdb.Genre {
+	genres := genresCache.genres
+	if genres != nil {
+		return *genres
+	}
+
+	genresCache.mux.Lock()
+	defer genresCache.mux.Unlock()
+
+	genres = genresCache.genres
+	if genres == nil {
+		apiGenres := getGenres(ctx, apikey)
+		genres = &apiGenres
+		genresCache.genres = genres
+	}
+
+	return *genres
+}
 
 //GGReq is the request to GetGame.
 type GGReq struct {
@@ -37,20 +139,63 @@ type GGReq struct {
 	Platform string
 }
 
-// GGResp is the response of the GetGame query.
-type GGResp struct {
-	Games        []gamesdb.Game
-	Boxart       map[string][]gamesdb.GameImage
-	ImageBaseURL gamesdb.ImageBaseUrlMeta
+// ParsedDeveloper is a normalized GamesDB Developer
+type ParsedDeveloper struct {
+	ID   int
+	Name string
+}
+
+// ParsedGenre is a normalized GamesDB Genre
+type ParsedGenre struct {
+	ID   int
+	Name string
+}
+
+// ParsedPublisher is a normalized GamesDB Publisher
+type ParsedPublisher struct {
+	ID   int
+	Name string
+}
+
+// ParsedGameImage is a normalized GamesDB GameImage
+type ParsedGameImage struct {
+	ID       int
+	Type     string
+	Side     string
+	Filename string
+}
+
+// ParsedImageSizeBaseUrls is a normalized GamesDB ImageBaseUrlMeta
+type ParsedImageSizeBaseUrls struct {
+	Original string
+	Thumb    string
+}
+
+// ParsedGame is  a normalized GamesDB Game
+type ParsedGame struct {
+	ID          int
+	Name        string
+	ReleaseDate string
+	//Platform    int
+	Players    int
+	Overview   string
+	Developers []ParsedDeveloper
+	Genres     []ParsedGenre
+	Publishers []ParsedPublisher
+
+	Images        map[string][]ParsedGameImage
+	ImageBaseUrls ParsedImageSizeBaseUrls
 }
 
 // GetGame gets the game information from the DB.
-func GetGame(ctx context.Context, apikey string, req GGReq) (*GGResp, error) {
+func GetGame(ctx context.Context, apikey string, req GGReq) (*ParsedGame, error) {
 	var games gamesdb.GamesByGameId
 	var resp *http.Response
 	var err error
 
-	fields := "players,publishers,genres,overview,last_updated,rating,platform,coop,youtube,os,processor,ram,hdd,video,sound,alternates"
+	// TODO(jpr): remove unneeded fields
+	//fields := "players,publishers,genres,overview,last_updated,rating,platform,coop,youtube,os,processor,ram,hdd,video,sound,alternates"
+	fields := "players,publishers,genres,overview,platform"
 
 	if req.ID != "" {
 		games, resp, err = apiClient.GamesApi.GamesByGameID(ctx, apikey, req.ID, &gamesdb.GamesByGameIDOpts{Fields: optional.NewString(fields)})
@@ -66,56 +211,84 @@ func GetGame(ctx context.Context, apikey string, req GGReq) (*GGResp, error) {
 		return nil, fmt.Errorf("getting game url:%s, error:%s", resp.Request.URL, err)
 	}
 
-	res := &GGResp{
-		Games: games.Data.Games,
+	if len(games.Data.Games) == 0 {
+		return nil, fmt.Errorf("game not found")
 	}
 
-	images, _, err := apiClient.GamesApi.GamesImages(ctx, apikey, req.ID, nil)
+	apiGame := games.Data.Games[0]
+	res := &ParsedGame{
+		ID:          int(apiGame.Id),
+		Name:        apiGame.GameTitle,
+		ReleaseDate: apiGame.ReleaseDate,
+		Players:     int(apiGame.Players),
+		Overview:    apiGame.Overview,
+	}
+
+	allGenres := getCachedGenres(ctx, apikey)
+	genres := []ParsedGenre{}
+	for _, genreID := range apiGame.Genres {
+		if apiGenre, ok := allGenres[strconv.Itoa(int(genreID))]; ok {
+			genres = append(genres, ParsedGenre{
+				ID:   int(apiGenre.Id),
+				Name: apiGenre.Name,
+			})
+		}
+	}
+	res.Genres = genres
+
+	allDevelopers := getCachedDevelopers(ctx, apikey)
+	developers := []ParsedDeveloper{}
+	for _, developerID := range apiGame.Developers {
+		if apiDeveloper, ok := allDevelopers[strconv.Itoa(int(developerID))]; ok {
+			developers = append(developers, ParsedDeveloper{
+				ID:   int(apiDeveloper.Id),
+				Name: apiDeveloper.Name,
+			})
+		}
+	}
+	res.Developers = developers
+
+	allPublishers := getCachedPublishers(ctx, apikey)
+	publishers := []ParsedPublisher{}
+	for _, publisherID := range apiGame.Publishers {
+		if apiPublisher, ok := allPublishers[strconv.Itoa(int(publisherID))]; ok {
+			publishers = append(publishers, ParsedPublisher{
+				ID:   int(apiPublisher.Id),
+				Name: apiPublisher.Name,
+			})
+		}
+	}
+	res.Publishers = publishers
+
+	for range games.Data.Games {
+		getCachedGenres(ctx, apikey)
+	}
+
+	images, _, err := apiClient.GamesApi.GamesImages(ctx, apikey, strconv.Itoa(res.ID), nil)
 	if err == nil {
-		res.ImageBaseURL = images.Data.BaseUrl
-		res.Boxart = images.Data.Images
+		res.ImageBaseUrls = ParsedImageSizeBaseUrls{
+			Original: images.Data.BaseUrl.Original,
+			Thumb:    images.Data.BaseUrl.Thumb,
+		}
+
+		parsedImages := make(map[string][]ParsedGameImage)
+		for key, val := range images.Data.Images {
+			result := parsedImages[key]
+			for _, image := range val {
+				result = append(result, ParsedGameImage{
+					ID:       int(image.Id),
+					Type:     image.Type,
+					Side:     image.Side,
+					Filename: image.Filename,
+				})
+			}
+			parsedImages[key] = result
+		}
+		res.Images = parsedImages
 	}
 
 	return res, nil
 }
-
-// GetGameList gets the game information from the DB.
-// func GetGameList(ctx context.Context, req GGLReq) (*GGLResp, error) {
-// 	u, err := url.Parse(gdbURL)
-// 	u.Path = gglPath
-// 	q := url.Values{}
-// 	if req.Name == "" {
-// 		return nil, fmt.Errorf("must provide Name")
-// 	}
-// 	q.Set("name", req.Name)
-// 	if req.Platform != "" {
-// 		q.Set("platform", req.Platform)
-// 	}
-// 	if req.Genre != "" {
-// 		q.Set("genre", req.Genre)
-// 	}
-// 	u.RawQuery = q.Encode()
-// 	hReq, err := http.NewRequest("GET", u.String(), nil)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	hReq = hReq.WithContext(ctx)
-// 	resp, err := http.DefaultClient.Do(hReq)
-// 	if err != nil {
-// 		return nil, fmt.Errorf("getting game list url:%s, error:%s", u, err)
-// 	}
-// 	defer resp.Body.Close()
-// 	r := &GGLResp{}
-// 	decoder := xml.NewDecoder(resp.Body)
-// 	if err := decoder.Decode(r); err != nil {
-// 		return nil, err
-// 	}
-// 	if r.XMLName.Local == "Error" {
-// 		return nil, fmt.Errorf("GetGameList error: %s", r.Err)
-// 	}
-// 	r.Err = ""
-// 	return r, nil
-// }
 
 // IsUp returns if thegamedb.net is up.
 func IsUp(ctx context.Context, apikey string) bool {

--- a/scraper.go
+++ b/scraper.go
@@ -636,6 +636,10 @@ func main() {
 			if apikey == "" {
 				apikey = os.Getenv("GAMESDB_APIKEY")
 			}
+			if apikey == "" {
+				fmt.Printf("No gamesdb api key provided")
+				return
+			}
 			if !*skipCheck {
 				if ok := gdb.IsUp(ctx, apikey); !ok {
 					fmt.Println("It appears that thegamesdb.net isn't up. If you are sure it is use -skip_check to bypass this error.")
@@ -700,6 +704,10 @@ func main() {
 			apikey := *gdbAPIkey
 			if apikey == "" {
 				apikey = os.Getenv("GAMESDB_APIKEY")
+			}
+			if apikey == "" {
+				fmt.Printf("No gamesdb api key provided")
+				return
 			}
 			arcadeSources = append(arcadeSources, &ds.NeoGeo{HM: hm, APIKey: apikey})
 		case "adb":

--- a/scraper.go
+++ b/scraper.go
@@ -644,7 +644,7 @@ func main() {
 			}
 			consoleSources = append(consoleSources, &ds.GDB{HM: hm, Hasher: hasher, APIKey: apikey})
 			//consoleSources = append(consoleSources, &ds.ScummVM{HM: hm})
-			//consoleSources = append(consoleSources, &ds.Daphne{HM: hm})
+			consoleSources = append(consoleSources, &ds.Daphne{HM: hm, APIKey: apikey})
 			consoleSources = append(consoleSources, &ds.NeoGeo{HM: hm, APIKey: apikey})
 		case "ss":
 			t := ss.Threads(ctx, dev, ss.UserInfo{*ssUser, *ssPassword})

--- a/scraper.go
+++ b/scraper.go
@@ -645,7 +645,7 @@ func main() {
 			consoleSources = append(consoleSources, &ds.GDB{HM: hm, Hasher: hasher, APIKey: apikey})
 			//consoleSources = append(consoleSources, &ds.ScummVM{HM: hm})
 			//consoleSources = append(consoleSources, &ds.Daphne{HM: hm})
-			//consoleSources = append(consoleSources, &ds.NeoGeo{HM: hm})
+			consoleSources = append(consoleSources, &ds.NeoGeo{HM: hm, APIKey: apikey})
 		case "ss":
 			t := ss.Threads(ctx, dev, ss.UserInfo{*ssUser, *ssPassword})
 			ssDS := &ds.SS{
@@ -697,7 +697,11 @@ func main() {
 			defer mds.Close()
 			arcadeSources = append(arcadeSources, mds)
 		case "gdb":
-			//arcadeSources = append(arcadeSources, &ds.NeoGeo{HM: hm})
+			apikey := *gdbAPIkey
+			if apikey == "" {
+				apikey = os.Getenv("GAMESDB_APIKEY")
+			}
+			arcadeSources = append(arcadeSources, &ds.NeoGeo{HM: hm, APIKey: apikey})
 		case "adb":
 			arcadeSources = append(arcadeSources, &ds.ADB{Limit: make(chan struct{}, 1)})
 		default:

--- a/scraper.go
+++ b/scraper.go
@@ -643,7 +643,7 @@ func main() {
 				}
 			}
 			consoleSources = append(consoleSources, &ds.GDB{HM: hm, Hasher: hasher, APIKey: apikey})
-			//consoleSources = append(consoleSources, &ds.ScummVM{HM: hm})
+			consoleSources = append(consoleSources, &ds.ScummVM{HM: hm, APIKey: apikey})
 			consoleSources = append(consoleSources, &ds.Daphne{HM: hm, APIKey: apikey})
 			consoleSources = append(consoleSources, &ds.NeoGeo{HM: hm, APIKey: apikey})
 		case "ss":

--- a/scraper.go
+++ b/scraper.go
@@ -75,6 +75,7 @@ var missing = flag.String("missing", "", "The `file` where information about ROM
 var overviewLen = flag.Int("overview_len", 0, "If set it will truncate the overview of roms to `N` characters + ellipsis.")
 var ssUser = flag.String("ss_user", "", "The `username` for registered ScreenScraper users.")
 var ssPassword = flag.String("ss_password", "", "The `password` for registered ScreenScraper users.")
+var gdbAPIkey = flag.String("gdb_apikey", "", "The gamesdb apikey received by https://forums.thegamesdb.net/viewforum.php?f=10")
 var updateCache = flag.Bool("update_cache", true, "If false, don't check for updates on locally cached files.")
 
 var errUserCanceled = errors.New("user canceled")
@@ -631,13 +632,17 @@ func main() {
 		switch src {
 		case "":
 		case "gdb":
+			apikey := *gdbAPIkey
+			if apikey == "" {
+				apikey = os.Getenv("GAMESDB_APIKEY")
+			}
 			if !*skipCheck {
-				if ok := gdb.IsUp(ctx); !ok {
+				if ok := gdb.IsUp(ctx, apikey); !ok {
 					fmt.Println("It appears that thegamesdb.net isn't up. If you are sure it is use -skip_check to bypass this error.")
 					continue
 				}
 			}
-			consoleSources = append(consoleSources, &ds.GDB{HM: hm, Hasher: hasher})
+			consoleSources = append(consoleSources, &ds.GDB{HM: hm, Hasher: hasher, APIKey: apikey})
 			//consoleSources = append(consoleSources, &ds.ScummVM{HM: hm})
 			//consoleSources = append(consoleSources, &ds.Daphne{HM: hm})
 			//consoleSources = append(consoleSources, &ds.NeoGeo{HM: hm})

--- a/scraper.go
+++ b/scraper.go
@@ -98,6 +98,22 @@ func isHidden(f string) bool {
 	return b != "." && strings.HasPrefix(b, ".")
 }
 
+const (
+	defaultGamesDbAPIKey = "fdb3e318c535c5f9fb5380d15cd6dbb5363cb197c1da897c7a268695658ceceb"
+)
+
+func getGamesDbAPIKey() string {
+	apikey := *gdbAPIkey
+	if apikey == "" {
+		apikey = os.Getenv("GAMESDB_APIKEY")
+	}
+	if apikey == "" {
+		fmt.Printf("No gamesdb api key provided, using default\n")
+		apikey = defaultGamesDbAPIKey
+	}
+	return apikey
+}
+
 type result struct {
 	ROM *rom.ROM
 	XML *rom.GameXML
@@ -632,14 +648,8 @@ func main() {
 		switch src {
 		case "":
 		case "gdb":
-			apikey := *gdbAPIkey
-			if apikey == "" {
-				apikey = os.Getenv("GAMESDB_APIKEY")
-			}
-			if apikey == "" {
-				fmt.Printf("No gamesdb api key provided")
-				return
-			}
+			apikey := getGamesDbAPIKey()
+
 			if !*skipCheck {
 				if ok := gdb.IsUp(ctx, apikey); !ok {
 					fmt.Println("It appears that thegamesdb.net isn't up. If you are sure it is use -skip_check to bypass this error.")
@@ -701,14 +711,7 @@ func main() {
 			defer mds.Close()
 			arcadeSources = append(arcadeSources, mds)
 		case "gdb":
-			apikey := *gdbAPIkey
-			if apikey == "" {
-				apikey = os.Getenv("GAMESDB_APIKEY")
-			}
-			if apikey == "" {
-				fmt.Printf("No gamesdb api key provided")
-				return
-			}
+			apikey := getGamesDbAPIKey()
 			arcadeSources = append(arcadeSources, &ds.NeoGeo{HM: hm, APIKey: apikey})
 		case "adb":
 			arcadeSources = append(arcadeSources, &ds.ADB{Limit: make(chan struct{}, 1)})

--- a/scraper.go
+++ b/scraper.go
@@ -638,9 +638,9 @@ func main() {
 				}
 			}
 			consoleSources = append(consoleSources, &ds.GDB{HM: hm, Hasher: hasher})
-			consoleSources = append(consoleSources, &ds.ScummVM{HM: hm})
-			consoleSources = append(consoleSources, &ds.Daphne{HM: hm})
-			consoleSources = append(consoleSources, &ds.NeoGeo{HM: hm})
+			//consoleSources = append(consoleSources, &ds.ScummVM{HM: hm})
+			//consoleSources = append(consoleSources, &ds.Daphne{HM: hm})
+			//consoleSources = append(consoleSources, &ds.NeoGeo{HM: hm})
 		case "ss":
 			t := ss.Threads(ctx, dev, ss.UserInfo{*ssUser, *ssPassword})
 			ssDS := &ds.SS{
@@ -692,7 +692,7 @@ func main() {
 			defer mds.Close()
 			arcadeSources = append(arcadeSources, mds)
 		case "gdb":
-			arcadeSources = append(arcadeSources, &ds.NeoGeo{HM: hm})
+			//arcadeSources = append(arcadeSources, &ds.NeoGeo{HM: hm})
 		case "adb":
 			arcadeSources = append(arcadeSources, &ds.ADB{Limit: make(chan struct{}, 1)})
 		default:


### PR DESCRIPTION
This should address #230, #237, #244, and #245

TheGamesDB updated to a new api a while back and v2 is pretty different:

- JSON instead of XML
- Request/response schemas are different
- Requires an API key (you can use my public key for now to test this `83cafde7c61f6f57f523241ca6abe58165cdc42c704ae0cd953a6846a9a463b6`)

This is the initial conversion of the existing code to support the new version. It relies on a "temporary" swagger client [I generated here](https://github.com/J-Swift/thegamesdb-swagger-client-go), but there is a decent amount of hand cleanup to get to that point. [See this issue](https://github.com/TheGamesDB/TheGamesDBv2/issues/19) I opened for more info. Once that is cleaned up, addressing future API updates should be fairly straightforward.

The new API supports batching which is great, but not currently implemented/supported in the codebase. I might tackle that next, as the API limits are not very generous (1500 req/month) and so batching is the only way a large initial scrape is going to work. I currently am making `4 + 2 * {number of games}` API requests per run of the scraper.

Note I had to learn golang for this and so let me know if there are any issues with how I've coded it up.