### PR TITLE
convert to yuv420p pixel format

### DIFF
--- a/rom/rom.go
+++ b/rom/rom.go
@@ -415,7 +415,7 @@ func convertVideo(p string) error {
 		"-c:v", "libx264",
         "-preset", "fast",
         "-crf", "23",
-        "-vf", "scale=w=320:h=-2",
+        "-vf", "scale=w=320:h=-2,format=yuv420p",
         "-c:a", "aac",
         "-b:a", "80k",
         outputFile)


### PR DESCRIPTION
Updated the `convertVideo` function's use of `ffmpeg` to ensure the pixel format is `yuv420p`. This is a more common format, and is required by the OMX player. OMX is the hardware accelerated video player that is becoming standard for Retropie.

I encountered a need for this with some MAME rom videos.

This may fix #194 

Here's a video to try with https://clone.screenscraper.fr/api/mediaVideoJeu.php?devid=sselph&devpassword=ROMHasher20160916&softname=sselph-scraper&crc=&md5=&sha1=&systemeid=158&jeuid=43783&media=video&mediaformat=mp4

Its stream info (reported by ffmpeg) is:
`Stream #0:0(und): Video: h264 (High 4:4:4 Predictive) (avc1 / 0x31637661), yuv444p, 224x768 [SAR 18:7 DAR 3:4], 136 kb/s, 29.97 fps, 29.97 tbr, 2997 tbn, 59.94 tbc (default)`

With this PR the new stream info is:
`Stream #0:0(und): Video: h264 (High) (avc1 / 0x31637661), yuv420p, 320x1098 [SAR 1647:640 DAR 3:4], 238 kb/s, 29.97 fps, 29.97 tbr, 11988 tbn, 59.94 tbc (default)`